### PR TITLE
Handle Transformers API drift and CUDA Graph StaticCache state

### DIFF
--- a/loader.py
+++ b/loader.py
@@ -455,7 +455,18 @@ def load_breeze_bundle(
     if _ACTIVE_BUNDLE is not None:
         unload_breeze_bundle(_ACTIVE_BUNDLE, reason="load settings changed")
 
-    from transformers import AutoTokenizer
+    from transformers import AutoConfig, AutoTokenizer
+
+    AutoConfig.register(
+        "breeze_depth_decoder_model",
+        native.BreezeDepthDecoderConfig,
+        exist_ok=True,
+    )
+    AutoConfig.register(
+        "breeze",
+        native.BreezeConfig,
+        exist_ok=True,
+    )
 
     quant_map = int8.scan_checkpoint_quantization(wfile)
     config_dict = native.read_config(model_dir)

--- a/runtime.py
+++ b/runtime.py
@@ -402,8 +402,14 @@ class _DepthRunner:
         stream.wait_stream(torch.cuda.current_stream())
         with torch.cuda.stream(stream):
             for _ in range(2):
+
+                self.cache.reset()
+
                 fn(static_in, *consts)
         torch.cuda.current_stream().wait_stream(stream)
+
+        self.cache.reset()
+
         graph = torch.cuda.CUDAGraph()
         # thread_local: ComfyUI's server thread (and monitor custom nodes)
         # poll CUDA stats from other threads; process-global capture treats


### PR DESCRIPTION
Hello, and thank you for providing such an excellent and timely plugin, which has made it possible to try Breeze TTS 2 in ComfyUI so quickly.

While using the project, I encountered several compatibility issues with a newer Transformers release (5.16.1). I made a few local adaptations and tested them with Transformers 4.57.3 and 5.16.1; both versions now work correctly in my environment. These findings and changes may be useful for future maintenance.

# Handle Transformers API drift and CUDA Graph StaticCache state

## Environment

- Windows / ComfyUI
- Transformers 5.16.1
- SDPA
- `eager` and `cuda_graphs` decode modes

## Issues covered

1. **P1 — Decorator:** incompatible `check_model_inputs` calling conventions.
2. **P2 — Configuration:** custom Breeze types are not registered with `AutoConfig`.
3. **P3 — Generation masks:** incompatible arguments in `native.py`.
4. **P4 — Codec masks:** the same argument incompatibility in `vendor/codec_model.py`.
5. **P5 — CUDA Graphs:** graph warm-up reuses a mutated `StaticCache`.

## Transformers version matrix

| Version | `check_model_inputs` | Mask functions | `StaticLayer.update()` | Failures in the original plugin |
| --- | --- | --- | --- | --- |
| 4.57.0–4.57.1 | Direct decorator; `@check_model_inputs()` fails | `input_embeds`; `cache_position` required | Writes to explicit `cache_position` | P1 |
| 4.57.2–4.57.3 | Decorator factory | `input_embeds`; `cache_position` required | Writes to explicit `cache_position` | None of P1/P3/P4/P5; 4.57.3 is the official baseline |
| 5.0–5.1 | Supports both forms through `func=None` | Still `input_embeds`; `cache_position` required | Writes to explicit `cache_position` | None of P1/P3/P4/P5 |
| 5.2–5.3 | Symbol absent; the existing fallback is used | Renamed to `inputs_embeds`; `cache_position` required | Writes to explicit `cache_position` | P4 |
| 5.4–5.8 | Direct decorator, deprecated; `@check_model_inputs()` fails | `inputs_embeds`; `cache_position` optional and unused, kept only for compatibility | Ignores explicit position and appends using `arange + cumulative_length` | P1, P4, and P5 in `cuda_graphs` mode |
| 5.9–5.16.1 | Direct decorator, deprecated | `inputs_embeds`; `cache_position` removed | Appends using `arange + cumulative_length` | P1, P3, P4, and P5 in `cuda_graphs` mode |

Transformers 4.57.3 and 5.16.1 were tested end to end. The intermediate boundaries above were verified from tagged Transformers source but were not all runtime-tested. P2 is a separate AutoConfig integration issue, not a confirmed Transformers version boundary; it was reproduced on 5.16.1.

## Problems and adaptations

### 1. `check_model_inputs()` fails during node import

The codec uses `@check_model_inputs()`. Direct-decorator releases raise:

```text
TypeError: check_model_inputs() missing 1 required positional argument: 'func'
```

The local adapter supports the factory form, direct form, and releases where the symbol is absent. This is a compatibility shim; signature inspection or migration to `merge_with_config_defaults` may be cleaner than catching `TypeError`.

### 2. Breeze config is unknown to `AutoConfig`

`AutoTokenizer.from_pretrained()` may resolve `model_type="breeze"` as a generic `PreTrainedConfig`. On 5.16.1 this later fails with:

```text
AttributeError: 'PreTrainedConfig' object has no attribute 'max_position_embeddings'
```

The local adaptation registers:

```text
breeze                     -> BreezeConfig
breeze_depth_decoder_model -> BreezeDepthDecoderConfig
```

The official Breeze implementation also registers both custom config types. Registration during module initialization, or passing the already-built `model.config` directly to `AutoTokenizer`, may be cleaner than registering during every load.

### 3. Generation mask calls pass removed or renamed arguments

Both causal-mask calls in `native.py` pass `cache_position` unconditionally. Transformers 5.9+ removed it, producing:

```text
TypeError: create_causal_mask() got an unexpected keyword argument 'cache_position'
```

The embedding keyword changed from `input_embeds` to `inputs_embeds` in Transformers 5.2. `native.py` already handled that rename; its new wrapper is required from 5.9 onward to remove `cache_position`. The wrapper inspects the installed signature once and only passes supported arguments.

### 4. Codec decoding has the same incompatibility

`vendor/codec_model.py` passes one `mask_kwargs` dictionary to both:

```python
create_causal_mask(**mask_kwargs)
create_sliding_window_causal_mask(**mask_kwargs)
```

The codec still uses `input_embeds`, so it becomes incompatible in Transformers 5.2. From 5.9 onward it also passes the removed `cache_position`. Both codec mask functions now use the same signature-based normalization, with their signatures inspected separately.

The helper is currently duplicated between `native.py` and `vendor/codec_model.py`; a shared adapter would reduce maintenance of private Transformers APIs.

### 5. CUDA Graph recording starts from a mutated `StaticCache`

`_record()` executes two warm-ups before capture. Each call mutates the same cache.

Through Transformers 5.3, `StaticLayer` writes using explicit `cache_position`. Starting in 5.4, it ignores that explicit position, tracks `cumulative_length`, and derives positions as:

```python
torch.arange(kv_length) + cumulative_length
```

For the depth decoder, a previous trial leaves length 16 in a cache with valid indices `0–16`. The next two-token prefill attempts positions `[16, 17]`, causing an out-of-bounds write. This source-level behavior exists from 5.4 onward; the failure was reproduced on 5.16.1.

The local adaptation resets the cache before each warm-up and once before capture:

```text
reset -> warm-up
reset -> warm-up
reset -> capture
```

These resets are outside the recorded CUDA Graph and are not replayed during inference. A dedicated capture cache or explicit state snapshot/restore may provide stronger isolation.

## Scope

The changes restore the tested 5.16.1 path through model loading, generation, depth decoding, codec decoding, and CUDA Graph capture. They are compatibility adaptations, not confirmation that every Transformers 5.x release is fully supported.

Commits:

- https://github.com/EarsT913831CALS/ComfyUI-Breeze-TTS-2/commit/c64ee8f3180cb4b02463ee34f4d05bb2ffb30c3e
- https://github.com/EarsT913831CALS/ComfyUI-Breeze-TTS-2/commit/a11161ff13988e18f6e08dd801aa3a38ad134b53